### PR TITLE
Add in the uglifyjs-webpack-plugin to fix webpack build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "resolve-url-loader": "^2.3.0",
     "sass-loader": "^7.0.3",
     "style-loader": "^0.21.0",
+    "uglifyjs-webpack-plugin": "^2.1.1",
     "webpack": "^4.16.1",
     "webpack-command": "^0.4.1",
     "webpack-notifier": "^1.6.0"


### PR DESCRIPTION
Hopefully a fix for https://github.com/hussainweb/drupal-bootstrap-webpack/issues/2 where we are missing a dependency on `webpack` build command execution.